### PR TITLE
Dot not catch exceptions on Ya Metrik API calls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,7 @@ import {
 } from './constants';
 
 function ymProxy(id, methodName, ...args) {
-    try {
-        window[trackerInstanceName(id)][methodName](...args);
-    } catch (ex) {
-        console.warn(ex);
-    }
+    window[trackerInstanceName(id)][methodName](...args);
 }
 
 function accountIdList() {

--- a/src/init.js
+++ b/src/init.js
@@ -18,13 +18,9 @@ export default function init(accounts, options = {}, version = '1') {
         accounts.forEach(id => {
             let defaultOptions = {id};
 
-            try {
-                window[trackerInstanceName(id)] = new Ya[trackerConstructorName(version)](
-                    Object.assign(defaultOptions, options)
-                );
-            } catch (ex) {
-                console.warn(ex);
-            }
+            window[trackerInstanceName(id)] = new Ya[trackerConstructorName(version)](
+                Object.assign(defaultOptions, options)
+            );
         });
     });
     accounts.forEach(id => {


### PR DESCRIPTION
I think this is more useful to pass any error from YM API up to caller in service which uses this library.
Currently, library users are not able to handle errors in YM API calls (as a result can't figure out why, for example, some goals are not tracked).
I think my approach is more flexible since library users may wrap ym calls with their own wrappers which uses `try { ym(...) } catch(e) {}` and do something with these errors.