### PR TITLE
fix: avoid returning `undefined` from `accountIdList()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ function ymProxy(id, methodName, ...args) {
 }
 
 function accountIdList() {
-    return typeof window !== 'undefined' ? window[accountListName] : [];
+    return typeof window !== 'undefined' ? (window[accountListName] || []) : [];
 }
 
 function ymAsyncProxy(ids) {


### PR DESCRIPTION
In cases, when YM was not properly initialized, or not required (for example, when component with Metrika is used in Storybook), `ym` is throwing exception.